### PR TITLE
Incredibly basic template merging functionality

### DIFF
--- a/internal/controller/cloudflared_controller.go
+++ b/internal/controller/cloudflared_controller.go
@@ -343,9 +343,8 @@ func (r *CloudflaredReconciler) podTemplateSpec(cloudflared *cfv1alpha1.Cloudfla
 
 	var containers []corev1.Container
 	for _, ctr := range template.Spec.Containers {
-		// apply custom modifications, if any
 		if ctr.Name == "cloudflared" {
-			ctr.DeepCopyInto(&container)
+			r.applyCustomizations(&container, &ctr)
 		} else {
 			containers = append(containers, ctr)
 		}
@@ -354,6 +353,12 @@ func (r *CloudflaredReconciler) podTemplateSpec(cloudflared *cfv1alpha1.Cloudfla
 	template.Spec.Containers = append(containers, container)
 
 	return template
+}
+
+func (r *CloudflaredReconciler) applyCustomizations(base, custom *corev1.Container) {
+	if len(custom.Image) > 0 {
+		base.Image = custom.Image
+	}
 }
 
 func (r *CloudflaredReconciler) labels(_ *cfv1alpha1.Cloudflared) map[string]string {

--- a/internal/controller/cloudflared_controller.go
+++ b/internal/controller/cloudflared_controller.go
@@ -309,7 +309,8 @@ func (r *CloudflaredReconciler) podTemplateSpec(cloudflared *cfv1alpha1.Cloudfla
 		}}
 	}
 
-	template.Spec.Containers = append(template.Spec.Containers, corev1.Container{
+	// create the base container
+	container := corev1.Container{
 		Name:  "cloudflared",
 		Image: defaultCloudflaredImage,
 		Command: []string{
@@ -338,7 +339,19 @@ func (r *CloudflaredReconciler) podTemplateSpec(cloudflared *cfv1alpha1.Cloudfla
 				Drop: []corev1.Capability{"ALL"},
 			},
 		},
-	})
+	}
+
+	var containers []corev1.Container
+	for _, ctr := range template.Spec.Containers {
+		// apply custom modifications, if any
+		if ctr.Name == "cloudflared" {
+			ctr.DeepCopyInto(&container)
+		} else {
+			containers = append(containers, ctr)
+		}
+	}
+
+	template.Spec.Containers = append(containers, container)
 
 	return template
 }

--- a/internal/controller/cloudflared_controller_test.go
+++ b/internal/controller/cloudflared_controller_test.go
@@ -264,7 +264,7 @@ var _ = Describe("Cloudflared Controller", func() {
 				Expect(owner.BlockOwnerDeletion).To(Equal(ptr.To(true)))
 			})
 
-			Context("with a custom cloudflared container", func() {
+			Context("with a custom cloudflared container image", func() {
 				BeforeEach(func() {
 					cloudflared.Spec.Template.Spec.Containers = []corev1.Container{{
 						Name:  "cloudflared",
@@ -449,6 +449,37 @@ var _ = Describe("Cloudflared Controller", func() {
 					strategy := resource.Spec.UpdateStrategy
 					Expect(strategy.Type).To(Equal(appsv1.RollingUpdateDaemonSetStrategyType))
 				})
+
+				Context("with a custom cloudflared container image", func() {
+					BeforeEach(func() {
+						cloudflared.Spec.Template.Spec.Containers = []corev1.Container{{
+							Name:  "cloudflared",
+							Image: expectedImage,
+						}}
+					})
+
+					It("should use the supplied image", func() {
+						resource := &appsv1.DaemonSet{}
+						Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
+
+						container := &corev1.Container{}
+						Expect(resource.Spec.Template.Spec.Containers).To(ContainElement(
+							HaveField("Name", "cloudflared"), container,
+						))
+						Expect(container.Image).To(Equal(expectedImage))
+					})
+
+					It("should keep the existing command", func() {
+						resource := &appsv1.DaemonSet{}
+						Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
+
+						container := &corev1.Container{}
+						Expect(resource.Spec.Template.Spec.Containers).To(ContainElement(
+							HaveField("Name", "cloudflared"), container,
+						))
+						Expect(container.Command).NotTo(BeEmpty())
+					})
+				})
 			})
 		})
 
@@ -594,6 +625,37 @@ var _ = Describe("Cloudflared Controller", func() {
 
 					strategy := resource.Spec.Strategy
 					Expect(strategy.Type).To(Equal(appsv1.RollingUpdateDeploymentStrategyType))
+				})
+
+				Context("with a custom cloudflared container image", func() {
+					BeforeEach(func() {
+						cloudflared.Spec.Template.Spec.Containers = []corev1.Container{{
+							Name:  "cloudflared",
+							Image: expectedImage,
+						}}
+					})
+
+					It("should use the supplied image", func() {
+						resource := &appsv1.Deployment{}
+						Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
+
+						container := &corev1.Container{}
+						Expect(resource.Spec.Template.Spec.Containers).To(ContainElement(
+							HaveField("Name", "cloudflared"), container,
+						))
+						Expect(container.Image).To(Equal(expectedImage))
+					})
+
+					It("should keep the existing command", func() {
+						resource := &appsv1.Deployment{}
+						Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
+
+						container := &corev1.Container{}
+						Expect(resource.Spec.Template.Spec.Containers).To(ContainElement(
+							HaveField("Name", "cloudflared"), container,
+						))
+						Expect(container.Command).NotTo(BeEmpty())
+					})
 				})
 			})
 		})

--- a/internal/controller/cloudflared_controller_test.go
+++ b/internal/controller/cloudflared_controller_test.go
@@ -263,6 +263,37 @@ var _ = Describe("Cloudflared Controller", func() {
 				Expect(owner.Controller).To(Equal(ptr.To(true)))
 				Expect(owner.BlockOwnerDeletion).To(Equal(ptr.To(true)))
 			})
+
+			Context("with a custom cloudflared container", func() {
+				BeforeEach(func() {
+					cloudflared.Spec.Template.Spec.Containers = []corev1.Container{{
+						Name:  "cloudflared",
+						Image: expectedImage,
+					}}
+				})
+
+				It("should use the supplied image", func() {
+					resource := &appsv1.DaemonSet{}
+					Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
+
+					container := &corev1.Container{}
+					Expect(resource.Spec.Template.Spec.Containers).To(ContainElement(
+						HaveField("Name", "cloudflared"), container,
+					))
+					Expect(container.Image).To(Equal(expectedImage))
+				})
+
+				It("should keep the existing command", func() {
+					resource := &appsv1.DaemonSet{}
+					Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
+
+					container := &corev1.Container{}
+					Expect(resource.Spec.Template.Spec.Containers).To(ContainElement(
+						HaveField("Name", "cloudflared"), container,
+					))
+					Expect(container.Command).NotTo(BeEmpty())
+				})
+			})
 		})
 
 		Context("and kind is DaemonSet", func() {


### PR DESCRIPTION
Templates containing a container named `cloudflared` will use the image from the template rather than the hardcoded default of `cloudflare/cloudflared:latest`