### PR TITLE
Adds IngressClass resource

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+- ../ingress-class
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook

--- a/config/ingress-class/ingress_class.yaml
+++ b/config/ingress-class/ingress_class.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: cloudflare-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: cloudflare
+spec:
+  controller: cloudflare.unmango.dev/ingress-controller

--- a/config/ingress-class/kustomization.yaml
+++ b/config/ingress-class/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- ingress_class.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/dist/chart/templates/ingress-class/ingress-class.yaml
+++ b/dist/chart/templates/ingress-class/ingress-class.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.ingressClass.enable }}
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: cloudflare-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: {{ .Values.ingressClass.name }}
+  annotations:
+    {{- if .Values.ingressClass.defaultClass }}
+    ingressclass.kubernetes.io/is-default-class: "true"
+    {{- end }}
+spec:
+  controller: cloudflare.unmango.dev/ingress-controller
+  {{- with .Values.ingressClass.parameters }}
+  parameters: {{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -86,3 +86,10 @@ certmanager:
 # [NETWORK POLICIES]: To enable NetworkPolicies set true
 networkPolicy:
   enable: false
+
+# [INGRESS]: To disable the IngressClass set false
+ingressClass:
+  enable: true
+  name: cloudflare
+  parameters: {}
+  defaultClass: false

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -17701,3 +17701,14 @@ spec:
       serviceAccountName: cloudflare-operator-controller-manager
       terminationGracePeriodSeconds: 10
       volumes: []
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: cloudflare-operator
+    control-plane: controller-manager
+  name: cloudflare-operator-cloudflare
+spec:
+  controller: cloudflare.unmango.dev/ingress-controller


### PR DESCRIPTION
Adds a new IngressClass resource to allow users to configure
Ingress resources using the cloudflare-operator.

The IngressClass is enabled by default and configurable
via Helm values.
