### PR TITLE
Ignores .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ go.work
 *.swp
 *.swo
 *~
+.DS_Store


### PR DESCRIPTION
Adds .DS_Store to the .gitignore file.

This prevents these macOS-specific files from being
tracked in the repository.
